### PR TITLE
Fixes how usable/available memory is read from the "free" command

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,8 @@ function run(args, cb) {
 						used: cl[2],
 						free: cl[3],
 						shared: cl[4],
-						buffers: cl[5],
-						cached: cl[6],
-						usable: cl[3] + cl[5] + cl[6]
+						buffers_cached: cl[5],
+						usable: cl[6]
 					};
 				    break;
 				case "-/+ buffers/cache:":


### PR DESCRIPTION
When this library was created 6 years ago, the output of 'free' probably was different than it is today. Today, the usable/available memory is in the 6th column of the output, while the buffer and cache memory is now combined in the 5th column. Example:

```bash
bash-5.1$ free
              total        used        free      shared  buff/cache   available
Mem:        6086968     3405688      415896      343080     2265384     2337588
Swap:       1048572        1292     1047280
```

This fix takes the value from the 6th column directly, which is what we want for the usable memory and combines the buffer and cache memory.